### PR TITLE
Use provider compatible #callback_url implementation

### DIFF
--- a/lib/omniauth/strategies/base.rb
+++ b/lib/omniauth/strategies/base.rb
@@ -29,6 +29,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('/v2/users/self').parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/omniauth-base.gemspec
+++ b/omniauth-base.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version = OmniAuth::Base::VERSION
 
-  gem.add_dependency 'omniauth-oauth2', '<= 1.4'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.1'
 end


### PR DESCRIPTION
The implementation of `#callback_url` in omniauth-oauth2 base strategy
changed in a way that is more correct according to oauth spec, but breaks
many oauth providers.

This change adapts this strategy to the old behavior. That way
omniauth-oauth2 1.4 can be used. That is better, as version 1.3.1 [seems
to be incompatible with Rails 5](https://github.com/intridea/omniauth-oauth2/issues/81#issuecomment-168456154). 

This fix is similar to what other strategies do. See e.g. [here](https://github.com/Shopify/omniauth-shopify-oauth2/commit/1a04cf0b4d168d91c0929dff731076bb04fb19ea) and [here](https://github.com/iainbeeston/omniauth-linkedin-oauth2/commit/a44d2cb39091665c6cc71a8ab861b3e8f30ea049).
